### PR TITLE
Set main_class for generated deps java binary

### DIFF
--- a/gwt/gwt.bzl
+++ b/gwt/gwt.bzl
@@ -240,6 +240,7 @@ def gwt_application(
   if len(srcs) > 0:
     native.java_binary(
       name = name + "-deps",
+      main_class = name,
       resources = resources,
       srcs = srcs,
       deps = all_deps,
@@ -247,6 +248,7 @@ def gwt_application(
   else:
     native.java_binary(
       name = name + "-deps",
+      main_class = name,
       resources = resources,
       runtime_deps = all_deps,
     )


### PR DESCRIPTION
Every java_binary needs a main class, which defaults to a generated name
depending on the provided sources and the current workspace path. This
fails when the BUILD file isn't located in a java source path.

Set the main_class property to the name of the application to satisfy
the java_binary rule for the generated deps java binary, which is valid
as the binary is only used for the GWT compilation.