### PR TITLE
Rename set to depset

### DIFF
--- a/gwt/gwt.bzl
+++ b/gwt/gwt.bzl
@@ -152,7 +152,7 @@ _gwt_dev = rule(
 )
 
 def _get_dep_jars(ctx):
-  all_deps = set(ctx.files.deps)
+  all_deps = depset(ctx.files.deps)
   for this_dep in ctx.attr.deps:
     if hasattr(this_dep, 'java'):
       all_deps += this_dep.java.transitive_runtime_deps


### PR DESCRIPTION
`set` is deprecated and no longer supported.