### PR TITLE
Don't test on Ubuntu 18.04, because it's broken.

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -2,10 +2,7 @@
 platforms:
   ubuntu1604:
     build_targets:
-    - "..."
-  ubuntu1804:
-    build_targets:
-    - "..."
+      - "//..."
   macos:
     build_targets:
-    - "..."
+      - "//..."


### PR DESCRIPTION
Apparently GWT is currently not compatible with Java 11, so there's no point in testing with it (and having a broken pipeline).

In case GWT 2.9 is ever released, we can probably re-enable this.

Fixes: https://github.com/bazelbuild/rules_gwt/issues/23