### PR TITLE
Fix invalid escape sequences

### DIFF
--- a/gwt/gwt.bzl
+++ b/gwt/gwt.bzl
@@ -116,7 +116,7 @@ def _gwt_dev_impl(ctx):
     cmd += 'javaRoots=("%s")\n' % '" "'.join(ctx.attr.java_roots)
     cmd += "srcClasspath=''\n"
     cmd += "for root in ${javaRoots[@]}; do\n"
-    cmd += "  rootDir=$(pwd | sed -e 's:\(.*\)%s.*:\\1:')../../../$root\n" % (ctx.attr.package_name)
+    cmd += "  rootDir=$(pwd | sed -e 's:\\(.*\\)%s.*:\\1:')../../../$root\n" % (ctx.attr.package_name)
     cmd += "  if [ -d $rootDir ]; then\n"
     cmd += "    srcClasspath+=:$rootDir\n"
     cmd += '    echo "Using Java sources rooted at $rootDir"\n'


### PR DESCRIPTION
`\(` and `\)` are invalid escape sequences in Starlark. This used to be silently ignored but now throws an error (see https://github.com/bazelbuild/bazel/commit/73402fa4aa5b9de46c9a4042b75e6fb332ad4a7f).